### PR TITLE
Added two mix generator tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ erl_crash.dump
 *.ez
 .DS_Store
 Guardfile
-
+/tmp

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ config :my_app, MyApp.Endpoint,
   ]
 ```
 
+## Generators
+
+This library also includes two `mix` tasks:
+
+`mix phoenix.gen.html.slime`
+`mix phoenix.gen.layout.slime`
+
+The first task creates a html resource in the same way `phoenix.gen.html` does
+with the exception that all files are `.slim` files instead of `.eex` files.
+
+The second task creates a new `web/templates/layout/app.html.slim` with the
+exact same content as the `app.html.eex` file. Do not forget to remove the old
+`app.html.eex` file.
+
 ## License
 
 MIT license. Please see [LICENSE][license] for details.

--- a/lib/mix/tasks/phoenix.gen.html.slime.ex
+++ b/lib/mix/tasks/phoenix.gen.html.slime.ex
@@ -1,0 +1,147 @@
+defmodule Mix.Tasks.Phoenix.Gen.Html.Slime do
+  use Mix.Task
+
+  @shortdoc "Generates controller, model and views for an HTML based resource using Slime templates"
+
+  @moduledoc """
+  This file was adapted from the original Phoenix html generator found here:
+
+  https://github.com/phoenixframework/phoenix/blob/v1.1/lib/mix/tasks/phoenix.gen.html.ex
+
+  Generates a Phoenix resource.
+
+      mix phoenix_slime.gen.html User users name:string age:integer
+
+  The first argument is the module name followed by
+  its plural name (used for resources and schema).
+
+  The generated resource will contain:
+
+    * a model in web/models
+    * a view in web/views
+    * a controller in web/controllers
+    * a migration file for the repository
+    * default CRUD templates in web/templates
+    * test files for generated model and controller
+
+  The generated model can be skipped with `--no-model`.
+  Read the documentation for `phoenix.gen.model` for more
+  information on attributes and namespaced resources.
+  """
+  def run(args) do
+    switches = [binary_id: :boolean, model: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
+    [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
+
+    attrs   = Mix.Phoenix.attrs(attrs)
+    binding = Mix.Phoenix.inflect(singular)
+    path    = binding[:path]
+    route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
+    binding = binding ++ [plural: plural, route: route, attrs: attrs,
+                          binary_id: opts[:binary_id],
+                          inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
+                          template_singular: String.replace(binding[:singular], "_", " "),
+                          template_plural: String.replace(plural, "_", " ")]
+
+    Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
+    Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")
+
+    Mix.Phoenix.copy_from paths(), "priv/templates/phoenix.gen.html", "", binding, [
+      {:eex, "controller.ex",       "web/controllers/#{path}_controller.ex"},
+      {:eex, "view.ex",             "web/views/#{path}_view.ex"},
+      {:eex, "controller_test.exs", "test/controllers/#{path}_controller_test.exs"},
+    ]
+
+    Mix.Phoenix.copy_from slime_paths(), "priv/templates/phoenix.gen.html.slime", "", binding, [
+      {:eex, "edit.html.eex",       "web/templates/#{path}/edit.html.slim"},
+      {:eex, "form.html.eex",       "web/templates/#{path}/form.html.slim"},
+      {:eex, "index.html.eex",      "web/templates/#{path}/index.html.slim"},
+      {:eex, "new.html.eex",        "web/templates/#{path}/new.html.slim"},
+      {:eex, "show.html.eex",       "web/templates/#{path}/show.html.slim"},
+    ]
+
+    instructions = """
+
+    Add the resource to your browser scope in web/router.ex:
+
+        resources "/#{route}", #{binding[:scoped]}Controller
+    """
+
+    if opts[:model] != false do
+      Mix.Task.run "phoenix.gen.model", ["--instructions", instructions|args]
+    else
+      Mix.shell.info instructions
+    end
+  end
+
+  defp validate_args!([_, plural | _] = args) do
+    cond do
+      String.contains?(plural, ":") ->
+        raise_with_help
+      plural != Phoenix.Naming.underscore(plural) ->
+        Mix.raise "expected the second argument, #{inspect plural}, to be all lowercase using snake_case convention"
+      true ->
+        args
+    end
+  end
+
+  defp validate_args!(_) do
+    raise_with_help
+  end
+
+  defp raise_with_help do
+    Mix.raise """
+    mix phoenix_slime.gen.html expects both singular and plural names
+    of the generated resource followed by any number of attributes:
+
+        mix phoenix_slime.gen.html User users name:string
+    """
+  end
+
+  defp inputs(attrs) do
+    Enum.map attrs, fn
+      {_, {:array, _}} ->
+        {nil, nil, nil}
+      {_, {:references, _}} ->
+        {nil, nil, nil}
+      {key, :integer}    ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :float}      ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, step: "any", class: "form-control"), error(key)}
+      {key, :decimal}    ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, step: "any", class: "form-control"), error(key)}
+      {key, :boolean}    ->
+        {label(key), ~s(= checkbox f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :text}       ->
+        {label(key), ~s(= textarea f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :date}       ->
+        {label(key), ~s(= date_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :time}       ->
+        {label(key), ~s(= time_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :datetime}   ->
+        {label(key), ~s(= datetime_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, _}           ->
+        {label(key), ~s(= text_input f, #{inspect(key)}, class: "form-control"), error(key)}
+    end
+  end
+
+  defp label(key) do
+    ~s(= label f, #{inspect(key)}, class: "control-label")
+  end
+
+  defp error(field) do
+    ~s(= error_tag f, #{inspect(field)})
+  end
+
+  defp paths do
+    [".", :phoenix]
+  end
+
+  defp slime_paths do
+    [".", :phoenix_slime]
+  end
+end

--- a/lib/mix/tasks/phoenix.gen.layout.slime.ex
+++ b/lib/mix/tasks/phoenix.gen.layout.slime.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.Phoenix.Gen.Layout.Slime do
+  use Mix.Task
+
+  @shortdoc "Generates a default Phoenix layout file in Slime"
+
+  @moduledoc """
+  Generates a Phoenix layout file in Slime.
+
+      mix phoenix_slime.gen.layout
+
+  """
+  def run(_args) do
+
+    binding = [application_module: "ApplicationName"]
+
+    Mix.Phoenix.copy_from slime_paths(), "priv/templates/phoenix.gen.layout.slime", "", binding, [
+      {:eex, "app.html.eex",       "web/templates/layout/app.html.slim"}
+    ]
+
+    instructions = """
+
+    A new web/templates/layout/app.html.slim file was generated. 
+    """
+    Mix.shell.info instructions
+  end
+
+  defp slime_paths do
+    [".", :phoenix_slime]
+  end
+end

--- a/priv/templates/phoenix.gen.html.slime/edit.html.eex
+++ b/priv/templates/phoenix.gen.html.slime/edit.html.eex
@@ -1,0 +1,5 @@
+h2 Edit <%= template_singular %>
+
+= render "form.html", changeset: @changeset, action: <%= singular %>_path(@conn, :update, @<%= singular %>)
+
+= link "Back", to: <%= singular %>_path(@conn, :index)

--- a/priv/templates/phoenix.gen.html.slime/form.html.eex
+++ b/priv/templates/phoenix.gen.html.slime/form.html.eex
@@ -1,0 +1,10 @@
+= form_for @changeset, @action, fn f ->
+  = if @changeset.action do
+    .alert.alert-danger
+      p Oops, something went wrong! Please check the errors below.
+<%= for {label, input, error} <- inputs, input do %>  .form-group
+    <%= label %>
+    <%= input %>
+    <%= error %>
+<% end %>  .form-group
+    = submit "Submit", class: "btn btn-primary"

--- a/priv/templates/phoenix.gen.html.slime/index.html.eex
+++ b/priv/templates/phoenix.gen.html.slime/index.html.eex
@@ -1,0 +1,19 @@
+h2 Listing <%= template_plural %>
+
+table.table
+  thead
+    tr
+<%= for {k, _} <- attrs do %>      th <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>
+<% end %>      th
+  tbody
+    = for <%= singular %> <- @<%= plural %> do
+      tr
+<%= for {k, _} <- attrs do %>        td= <%= singular %>.<%= k %>
+<% end %>        td class="text-right"
+          = link "Show", to: <%= singular %>_path(@conn, :show, <%= singular %>), class: "btn btn-default btn-xs"
+          | &nbsp;
+          = link "Edit", to: <%= singular %>_path(@conn, :edit, <%= singular %>), class: "btn btn-default btn-xs"
+          | &nbsp;
+          = link "Delete", to: <%= singular %>_path(@conn, :delete, <%= singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs"
+
+= link "New <%= template_singular %>", to: <%= singular %>_path(@conn, :new)

--- a/priv/templates/phoenix.gen.html.slime/new.html.eex
+++ b/priv/templates/phoenix.gen.html.slime/new.html.eex
@@ -1,0 +1,5 @@
+h2 New <%= template_singular %>
+
+= render "form.html", changeset: @changeset, action: <%= singular %>_path(@conn, :create)
+
+= link "Back", to: <%= singular %>_path(@conn, :index)

--- a/priv/templates/phoenix.gen.html.slime/show.html.eex
+++ b/priv/templates/phoenix.gen.html.slime/show.html.eex
@@ -1,0 +1,10 @@
+h2 Show <%= template_singular %>
+
+ul
+<%= for {k, _} <- attrs do %>  li
+    strong <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>:&nbsp;
+    = @<%= singular %>.<%= k %>
+<% end %>
+= link "Edit", to: <%= singular %>_path(@conn, :edit, @<%= singular %>)
+| &nbsp;
+= link "Back", to: <%= singular %>_path(@conn, :index)

--- a/priv/templates/phoenix.gen.layout.slime/app.html.eex
+++ b/priv/templates/phoenix.gen.layout.slime/app.html.eex
@@ -1,0 +1,27 @@
+doctype html
+html lang="en"
+  head
+    meta charset="utf-8"
+    meta content="IE=edge" http-equiv="X-UA-Compatible"
+    meta content="width=device-width, initial-scale=1" name="viewport"
+    meta content="" name="description"
+    meta content="" name="author"
+    title Hello <%= application_module %>!
+    link rel="stylesheet" href="#{static_path(@conn, "/css/app.css")}"
+
+  body
+    .container
+      header.header
+        nav role="navigation"
+          ul.nav.nav-pills.pull-right
+            li
+              a href="http://www.phoenixframework.org/docs" Get Started
+        span.logo
+
+      p.alert.alert-info role="alert"= get_flash(@conn, :info)
+      p.alert.alert-danger role="alert"= get_flash(@conn, :error)
+
+      main role="main"
+        = render @view_module, @view_template, assigns
+
+    script src="#{static_path(@conn, "/js/app.js")}"

--- a/test/mix/mix_helper.exs
+++ b/test/mix/mix_helper.exs
@@ -1,0 +1,48 @@
+# Get Mix output sent to the current
+# process to avoid polluting tests.
+Mix.shell(Mix.Shell.Process)
+
+defmodule MixHelper do
+  import ExUnit.Assertions
+
+  def tmp_path do
+    Path.expand("../../tmp", __DIR__)
+  end
+
+  def in_tmp(which, function) do
+    path = Path.join(tmp_path, which)
+    File.rm_rf! path
+    File.mkdir_p! path
+    File.cd! path, function
+  end
+
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} to not exist, but it does"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      is_list(match) ->
+        assert_file file, &(Enum.each(match, fn(m) -> assert &1 =~ m end))
+      is_binary(match) or Regex.regex?(match) ->
+        assert_file file, &(assert &1 =~ match)
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+    end
+  end
+
+  def with_generator_env(new_env, fun) do
+    old = Application.get_env(:phoenix, :generators)
+    Application.put_env(:phoenix, :generators, new_env)
+    try do
+      fun.()
+    after
+      Application.put_env(:phoenix, :generators, old)
+    end
+  end
+end

--- a/test/mix/tasks/phoenix.gen.html.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.html.slime_test.exs
@@ -1,0 +1,215 @@
+Code.require_file "../mix_helper.exs", __DIR__
+
+defmodule PhoenixSlime.DupHTMLController do
+end
+
+defmodule PhoenixSlime.DupHTMLView do
+end
+
+defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "generates html resource" do
+    in_tmp "generates html resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["user", "users", "name", "age:integer", "height:decimal",
+                                      "nicks:array:text", "famous:boolean", "born_at:datetime",
+                                      "secret:uuid", "first_login:date", "alarm:time",
+                                      "address_id:references:addresses"]
+
+      assert_file "web/models/user.ex"
+      assert_file "test/models/user_test.exs"
+      assert [_] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      assert_file "web/controllers/user_controller.ex", fn file ->
+        assert file =~ "defmodule PhoenixSlime.UserController"
+        assert file =~ "use PhoenixSlime.Web, :controller"
+        assert file =~ "Repo.get!"
+      end
+
+      assert_file "web/views/user_view.ex", fn file ->
+        assert file =~ "defmodule PhoenixSlime.UserView do"
+        assert file =~ "use PhoenixSlime.Web, :view"
+      end
+
+      assert_file "web/templates/user/edit.html.slim", fn file ->
+        assert file =~ "action: user_path(@conn, :update, @user)"
+      end
+
+      assert_file "web/templates/user/form.html.slim", fn file ->
+        assert file =~ ~s(= text_input f, :name, class: "form-control")
+        assert file =~ ~s(= number_input f, :age, class: "form-control")
+        assert file =~ ~s(= number_input f, :height, step: "any", class: "form-control")
+        assert file =~ ~s(= checkbox f, :famous, class: "form-control")
+        assert file =~ ~s(= datetime_select f, :born_at, class: "form-control")
+        assert file =~ ~s(= text_input f, :secret, class: "form-control")
+        assert file =~ ~s(= label f, :name, class: "control-label")
+        assert file =~ ~s(= label f, :age, class: "control-label")
+        assert file =~ ~s(= label f, :height, class: "control-label")
+        assert file =~ ~s(= label f, :famous, class: "control-label")
+        assert file =~ ~s(= label f, :born_at, class: "control-label")
+        assert file =~ ~s(= label f, :secret, class: "control-label")
+
+        refute file =~ ~s(= label f, :address_id)
+        refute file =~ ~s(= number_input f, :address_id)
+        refute file =~ ":nicks"
+      end
+
+      assert_file "web/templates/user/index.html.slim", fn file ->
+        assert file =~ "th Name"
+        assert file =~ "= for user <- @users do"
+        assert file =~ "td= user.name"
+      end
+
+      assert_file "web/templates/user/new.html.slim", fn file ->
+        assert file =~ "action: user_path(@conn, :create)"
+      end
+
+      assert_file "web/templates/user/show.html.slim", fn file ->
+        assert file =~ "strong Name:"
+        assert file =~ "= @user.name"
+      end
+
+      assert_file "test/controllers/user_controller_test.exs", fn file ->
+        assert file =~ "defmodule PhoenixSlime.UserControllerTest"
+        assert file =~ "use PhoenixSlime.ConnCase"
+
+        assert file =~ ~S|@valid_attrs %{age: 42|
+        assert file =~ ~S|@invalid_attrs %{}|
+        refute file =~ ~S|address_id: nil|
+
+        assert file =~ ~S|test "lists all entries on index"|
+        assert file =~ ~S|conn = get conn, user_path(conn, :index)|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Listing users"|
+
+        assert file =~ ~S|test "renders form for new resources"|
+        assert file =~ ~S|conn = get conn, user_path(conn, :new)|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "New user"|
+
+        assert file =~ ~S|test "creates resource and redirects when data is valid"|
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @valid_attrs|
+        assert file =~ ~S|assert redirected_to(conn) == user_path(conn, :index)|
+        assert file =~ ~r/creates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+
+        assert file =~ ~S|test "does not create resource and renders errors when data is invalid"|
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @invalid_attrs|
+
+        assert file =~ ~S|test "shows chosen resource"|
+        assert file =~ ~S|user = Repo.insert! %User{}|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Show user"|
+
+        assert file =~ ~S|test "renders form for editing chosen resource"|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Edit user"|
+
+        assert file =~ ~S|test "updates chosen resource and redirects when data is valid"|
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_attrs|
+        assert file =~ ~r/updates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+
+        assert file =~ ~S|test "does not update chosen resource and renders errors when data is invalid"|
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @invalid_attrs|
+
+        assert file =~ ~S|test "deletes chosen resource"|
+        assert file =~ ~S|conn = delete conn, user_path(conn, :delete, user)|
+      end
+
+      assert_received {:mix_shell, :info, ["\nAdd the resource" <> _ = message]}
+      assert message =~ ~s(resources "/users", UserController)
+    end
+  end
+
+  test "generates nested resource" do
+    in_tmp "generates nested resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.SuperUser", "super_users", "name:string"]
+
+      assert_file "web/models/admin/super_user.ex"
+      assert [_] = Path.wildcard("priv/repo/migrations/*_create_admin_super_user.exs")
+
+      assert_file "web/controllers/admin/super_user_controller.ex", fn file ->
+        assert file =~ "defmodule PhoenixSlime.Admin.SuperUserController"
+        assert file =~ "use PhoenixSlime.Web, :controller"
+        assert file =~ "Repo.get!"
+      end
+
+      assert_file "web/views/admin/super_user_view.ex", fn file ->
+        assert file =~ "defmodule PhoenixSlime.Admin.SuperUserView do"
+        assert file =~ "use PhoenixSlime.Web, :view"
+      end
+
+      assert_file "web/templates/admin/super_user/edit.html.slim", fn file ->
+        assert file =~ "h2 Edit super user"
+        assert file =~ "action: super_user_path(@conn, :update, @super_user)"
+      end
+
+      assert_file "web/templates/admin/super_user/form.html.slim", fn file ->
+        assert file =~ ~s(= text_input f, :name, class: "form-control")
+      end
+
+      assert_file "web/templates/admin/super_user/index.html.slim", fn file ->
+        assert file =~ "h2 Listing super users"
+        assert file =~ "th Name"
+        assert file =~ "= for super_user <- @super_users do"
+      end
+
+      assert_file "web/templates/admin/super_user/new.html.slim", fn file ->
+        assert file =~ "h2 New super user"
+        assert file =~ "action: super_user_path(@conn, :create)"
+      end
+
+      assert_file "web/templates/admin/super_user/show.html.slim", fn file ->
+        assert file =~ "h2 Show super user"
+        assert file =~ "strong Name:"
+        assert file =~ "= @super_user.name"
+      end
+
+      assert_file "test/controllers/admin/super_user_controller_test.exs", fn file ->
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Listing super users"|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "New super user"|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Show super user"|
+        assert file =~ ~S|assert html_response(conn, 200) =~ "Edit super user"|
+      end
+
+      assert_received {:mix_shell, :info, ["\nAdd the resource" <> _ = message]}
+      assert message =~ ~s(resources "/admin/super_users", Admin.SuperUserController)
+    end
+  end
+
+  test "generates html resource without model" do
+    in_tmp "generates html resource without model", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.User", "users", "--no-model", "name:string"]
+
+      refute File.exists? "web/models/admin/user.ex"
+      assert [] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
+
+      assert_file "web/templates/admin/user/form.html.slim", fn file ->
+        refute file =~ ~s(--no-model)
+      end
+    end
+  end
+
+  test "plural can't contain a colon" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.User", "name:string", "foo:string"]
+    end
+  end
+
+  test "plural can't have uppercased characters or camelized format" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.User", "Users", "foo:string"]
+    end
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.User", "AdminUsers", "foo:string"]
+    end
+  end
+
+  test "name is already defined" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.Slime.run ["DupHTML", "duphtmls"]
+    end
+  end
+end

--- a/test/mix/tasks/phoenix.gen.layout.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.layout.slime_test.exs
@@ -1,0 +1,23 @@
+Code.require_file "../mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phoenix.Gen.Layout.SlimeTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "generates a slime layout file" do
+    in_tmp "generates slime layout file", fn ->
+      Mix.Tasks.Phoenix.Gen.Layout.Slime.run []
+
+      assert_file "web/templates/layout/app.html.slim", fn file ->
+        assert file =~ "p.alert.alert-info"
+        assert file =~ "p.alert.alert-danger"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I am not sure if you want to broaden the scope of the project to include generators, but I have added them in just in case. There are two new mix generator tasks:

`mix phoenix_slim.gen.html` which is the same as `phoenix.gen.html` except it creates `slim` files instead of `eex` files. The other is `mix phoenix_slim.gen.layout` which creates a new `app.html.slim` file in the `web/templates/layouts/` directory. 

The problem here is that the generators need to keep pace with with Phoenix releases because if those generators change (which they already will between 1.1 and 1.2) these ones should as well. I would be happy to keep track of them, but if you don't want these in your project I can create a new mix project (ex: `phoenix_slime_generators`) and keep track of them there.

I tested these generators with a new phoenix app (1.1.1) and could not find any differences to the EEx versions.
