### PR TITLE
Fix typo in test description

### DIFF
--- a/test/phoenix_slime_test.exs
+++ b/test/phoenix_slime_test.exs
@@ -16,7 +16,7 @@ defmodule PhoenixSlimeTest do
     assert html == {:safe, [[["" | "<html><body>"], "" | "<h2>New Template</h2>"] | "</body></html>"]}
   end
 
-  test "render a haml template without layout" do
+  test "render a slim template without layout" do
     html = View.render(MyApp.PageView, "new.html", [])
     assert html == {:safe, ["" | "<h2>New Template</h2>"]}
   end


### PR DESCRIPTION
Just a small typo I noticed while reading the tests.
The template is written in slim, not haml.

I'm guessing this was copied over from https://github.com/chrismccord/phoenix_haml/blob/master/test/phoenix_haml_test.exs#L19 😄 
