### PR TITLE
fixing html generator for phoenix 1.1.4

### DIFF
--- a/lib/mix/tasks/phoenix.gen.html.slime.ex
+++ b/lib/mix/tasks/phoenix.gen.html.slime.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.Slime do
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, attrs: attrs,
+                          binary_id: opts[:binary_id],
                           sample_id: sample_id(opts),
                           inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
                           template_singular: String.replace(binding[:singular], "_", " "),


### PR DESCRIPTION
WIth this fix, all tests are passing for the following version of phoenix: `1.1`, `1.1.4` and `1.2 rc-1`. This fix issue #20. 
