### PR TITLE
Switch to Slime v0.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSlime.Mixfile do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule PhoenixSlime.Mixfile do
     [{:phoenix, "~> 1.1 or ~> 1.2"},
      {:phoenix_html, "~> 2.3"},
      {:cowboy, "~> 1.0"},
-     {:slime, "~> 0.14"}]
+     {:slime, "~> 0.15"}]
   end
 
   defp package do


### PR DESCRIPTION
Adds support for embedded engines and removes compiler warnings on Elixir 1.3.

Almost not worth a pull request as the change is absolutely tiny. Just discard it if you prefer a proper release from your side.
