### PR TITLE
add ability to prefer .slime over .slim for generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ This library also includes two `mix` tasks:
 `mix phoenix.gen.layout.slime`
 
 The first task creates a html resource in the same way `phoenix.gen.html` does
-with the exception that all files are `.slim` files instead of `.eex` files.
+with the exception that all files are `.slime` files instead of `.eex` files.
 
-The second task creates a new `web/templates/layout/app.html.slim` with the
+The second task creates a new `web/templates/layout/app.html.slime` with the
 exact same content as the `app.html.eex` file. Do not forget to remove the old
 `app.html.eex` file.
 
-Generated files have `.slim` extension by default. If you prefer `.slime`, you could add the following line to your config:
+Generated files have `.slime` extension by default. If you prefer `.slim`, you could add the following line to your config:
 
 ```elixir
-config :phoenix_slime, :use_slime_extension, true
+config :phoenix_slime, :use_slim_extension, true
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The second task creates a new `web/templates/layout/app.html.slim` with the
 exact same content as the `app.html.eex` file. Do not forget to remove the old
 `app.html.eex` file.
 
+Generated files have `.slim` extension by default. If you prefer `.slime`, you could add the following line to your config:
+
+```elixir
+config :phoenix_slime, :use_slime_extension, true
+```
+
 ## License
 
 MIT license. Please see [LICENSE][license] for details.

--- a/lib/mix/tasks/phoenix.gen.html.slime.ex
+++ b/lib/mix/tasks/phoenix.gen.html.slime.ex
@@ -57,12 +57,13 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.Slime do
       {:eex, "controller_test.exs", "test/controllers/#{path}_controller_test.exs"},
     ]
 
+    extension = PhoenixSlime.ConfiguredExtension.file_extension
     Mix.Phoenix.copy_from slime_paths(), "priv/templates/phoenix.gen.html.slime", "", binding, [
-      {:eex, "edit.html.eex",       "web/templates/#{path}/edit.html.slim"},
-      {:eex, "form.html.eex",       "web/templates/#{path}/form.html.slim"},
-      {:eex, "index.html.eex",      "web/templates/#{path}/index.html.slim"},
-      {:eex, "new.html.eex",        "web/templates/#{path}/new.html.slim"},
-      {:eex, "show.html.eex",       "web/templates/#{path}/show.html.slim"},
+      {:eex, "edit.html.eex",       "web/templates/#{path}/edit.html.#{extension}"},
+      {:eex, "form.html.eex",       "web/templates/#{path}/form.html.#{extension}"},
+      {:eex, "index.html.eex",      "web/templates/#{path}/index.html.#{extension}"},
+      {:eex, "new.html.eex",        "web/templates/#{path}/new.html.#{extension}"},
+      {:eex, "show.html.eex",       "web/templates/#{path}/show.html.#{extension}"},
     ]
 
     instructions = """

--- a/lib/mix/tasks/phoenix.gen.layout.slime.ex
+++ b/lib/mix/tasks/phoenix.gen.layout.slime.ex
@@ -13,13 +13,14 @@ defmodule Mix.Tasks.Phoenix.Gen.Layout.Slime do
 
     binding = [application_module: "ApplicationName"]
 
+    extension = PhoenixSlime.ConfiguredExtension.file_extension
     Mix.Phoenix.copy_from slime_paths(), "priv/templates/phoenix.gen.layout.slime", "", binding, [
-      {:eex, "app.html.eex",       "web/templates/layout/app.html.slim"}
+      {:eex, "app.html.eex",       "web/templates/layout/app.html.#{extension}"}
     ]
 
     instructions = """
 
-    A new web/templates/layout/app.html.slim file was generated. 
+    A new web/templates/layout/app.html.#{extension} file was generated.
     """
     Mix.shell.info instructions
   end

--- a/lib/phoenix_slime/configured_extension.ex
+++ b/lib/phoenix_slime/configured_extension.ex
@@ -1,8 +1,8 @@
 defmodule PhoenixSlime.ConfiguredExtension do
   def file_extension do
-    case Application.fetch_env(:phoenix_slime, :use_slime_extension) do
-      {:ok, true} -> "slime"
-      _ -> "slim"
+    case Application.fetch_env(:phoenix_slime, :use_slim_extension) do
+      {:ok, true} -> "slim"
+      _ -> "slime"
     end
   end
 end

--- a/lib/phoenix_slime/configured_extension.ex
+++ b/lib/phoenix_slime/configured_extension.ex
@@ -1,0 +1,8 @@
+defmodule PhoenixSlime.ConfiguredExtension do
+  def file_extension do
+    case Application.fetch_env(:phoenix_slime, :use_slime_extension) do
+      {:ok, true} -> "slime"
+      _ -> "slim"
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixSlime.Mixfile do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "1.0.0"
 
   def project do
     [

--- a/test/mix/tasks/phoenix.gen.html.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.html.slime_test.exs
@@ -191,6 +191,29 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
     end
   end
 
+  describe "when :use_slime_extension env is set to true" do
+    setup do
+      Application.put_env(:phoenix_slime, :use_slime_extension, true)
+      on_exit fn ->
+        Application.delete_env(:phoenix_slime, :use_slime_extension)
+      end
+      :ok
+    end
+
+    test "generates files with .slime extension " do
+      in_tmp "generates .slime", fn ->
+        Mix.Tasks.Phoenix.Gen.Html.Slime.run ["User", "users"]
+
+        assert File.exists? "web/templates/user/edit.html.slime"
+        assert File.exists? "web/templates/user/form.html.slime"
+        assert File.exists? "web/templates/user/index.html.slime"
+        assert File.exists? "web/templates/user/new.html.slime"
+        assert File.exists? "web/templates/user/show.html.slime"
+      end
+    end
+  end
+
+
   test "plural can't contain a colon" do
     assert_raise Mix.Error, fn ->
       Mix.Tasks.Phoenix.Gen.Html.Slime.run ["Admin.User", "name:string", "foo:string"]

--- a/test/mix/tasks/phoenix.gen.html.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.html.slime_test.exs
@@ -37,11 +37,11 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
         assert file =~ "use PhoenixSlime.Web, :view"
       end
 
-      assert_file "web/templates/user/edit.html.slim", fn file ->
+      assert_file "web/templates/user/edit.html.slime", fn file ->
         assert file =~ "action: user_path(@conn, :update, @user)"
       end
 
-      assert_file "web/templates/user/form.html.slim", fn file ->
+      assert_file "web/templates/user/form.html.slime", fn file ->
         assert file =~ ~s(= text_input f, :name, class: "form-control")
         assert file =~ ~s(= number_input f, :age, class: "form-control")
         assert file =~ ~s(= number_input f, :height, step: "any", class: "form-control")
@@ -60,17 +60,17 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
         refute file =~ ":nicks"
       end
 
-      assert_file "web/templates/user/index.html.slim", fn file ->
+      assert_file "web/templates/user/index.html.slime", fn file ->
         assert file =~ "th Name"
         assert file =~ "= for user <- @users do"
         assert file =~ "td= user.name"
       end
 
-      assert_file "web/templates/user/new.html.slim", fn file ->
+      assert_file "web/templates/user/new.html.slime", fn file ->
         assert file =~ "action: user_path(@conn, :create)"
       end
 
-      assert_file "web/templates/user/show.html.slim", fn file ->
+      assert_file "web/templates/user/show.html.slime", fn file ->
         assert file =~ "strong Name:"
         assert file =~ "= @user.name"
       end
@@ -140,27 +140,27 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
         assert file =~ "use PhoenixSlime.Web, :view"
       end
 
-      assert_file "web/templates/admin/super_user/edit.html.slim", fn file ->
+      assert_file "web/templates/admin/super_user/edit.html.slime", fn file ->
         assert file =~ "h2 Edit super user"
         assert file =~ "action: super_user_path(@conn, :update, @super_user)"
       end
 
-      assert_file "web/templates/admin/super_user/form.html.slim", fn file ->
+      assert_file "web/templates/admin/super_user/form.html.slime", fn file ->
         assert file =~ ~s(= text_input f, :name, class: "form-control")
       end
 
-      assert_file "web/templates/admin/super_user/index.html.slim", fn file ->
+      assert_file "web/templates/admin/super_user/index.html.slime", fn file ->
         assert file =~ "h2 Listing super users"
         assert file =~ "th Name"
         assert file =~ "= for super_user <- @super_users do"
       end
 
-      assert_file "web/templates/admin/super_user/new.html.slim", fn file ->
+      assert_file "web/templates/admin/super_user/new.html.slime", fn file ->
         assert file =~ "h2 New super user"
         assert file =~ "action: super_user_path(@conn, :create)"
       end
 
-      assert_file "web/templates/admin/super_user/show.html.slim", fn file ->
+      assert_file "web/templates/admin/super_user/show.html.slime", fn file ->
         assert file =~ "h2 Show super user"
         assert file =~ "strong Name:"
         assert file =~ "= @super_user.name"
@@ -185,30 +185,30 @@ defmodule Mix.Tasks.Phoenix.Gen.Html.SlimeTest do
       refute File.exists? "web/models/admin/user.ex"
       assert [] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
 
-      assert_file "web/templates/admin/user/form.html.slim", fn file ->
+      assert_file "web/templates/admin/user/form.html.slime", fn file ->
         refute file =~ ~s(--no-model)
       end
     end
   end
 
-  describe "when :use_slime_extension env is set to true" do
+  describe "when :use_slim_extension env is set to true" do
     setup do
-      Application.put_env(:phoenix_slime, :use_slime_extension, true)
+      Application.put_env(:phoenix_slime, :use_slim_extension, true)
       on_exit fn ->
-        Application.delete_env(:phoenix_slime, :use_slime_extension)
+        Application.delete_env(:phoenix_slime, :use_slim_extension)
       end
       :ok
     end
 
-    test "generates files with .slime extension " do
-      in_tmp "generates .slime", fn ->
+    test "generates files with .slim extension " do
+      in_tmp "generates .slim", fn ->
         Mix.Tasks.Phoenix.Gen.Html.Slime.run ["User", "users"]
 
-        assert File.exists? "web/templates/user/edit.html.slime"
-        assert File.exists? "web/templates/user/form.html.slime"
-        assert File.exists? "web/templates/user/index.html.slime"
-        assert File.exists? "web/templates/user/new.html.slime"
-        assert File.exists? "web/templates/user/show.html.slime"
+        assert File.exists? "web/templates/user/edit.html.slim"
+        assert File.exists? "web/templates/user/form.html.slim"
+        assert File.exists? "web/templates/user/index.html.slim"
+        assert File.exists? "web/templates/user/new.html.slim"
+        assert File.exists? "web/templates/user/show.html.slim"
       end
     end
   end

--- a/test/mix/tasks/phoenix.gen.layout.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.layout.slime_test.exs
@@ -20,4 +20,21 @@ defmodule Mix.Tasks.Phoenix.Gen.Layout.SlimeTest do
 
     end
   end
+
+  describe "when :use_slime_extension env is set to true" do
+    setup do
+      Application.put_env(:phoenix_slime, :use_slime_extension, true)
+      on_exit fn ->
+        Application.delete_env(:phoenix_slime, :use_slime_extension)
+      end
+      :ok
+    end
+
+    test "generates a file with .slime extension " do
+      in_tmp "generates .slime", fn ->
+        Mix.Tasks.Phoenix.Gen.Layout.Slime.run []
+        assert File.exists? "web/templates/layout/app.html.slime"
+      end
+    end
+  end
 end

--- a/test/mix/tasks/phoenix.gen.layout.slime_test.exs
+++ b/test/mix/tasks/phoenix.gen.layout.slime_test.exs
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Layout.SlimeTest do
     in_tmp "generates slime layout file", fn ->
       Mix.Tasks.Phoenix.Gen.Layout.Slime.run []
 
-      assert_file "web/templates/layout/app.html.slim", fn file ->
+      assert_file "web/templates/layout/app.html.slime", fn file ->
         assert file =~ "p.alert.alert-info"
         assert file =~ "p.alert.alert-danger"
       end
@@ -21,19 +21,19 @@ defmodule Mix.Tasks.Phoenix.Gen.Layout.SlimeTest do
     end
   end
 
-  describe "when :use_slime_extension env is set to true" do
+  describe "when :use_slim_extension env is set to true" do
     setup do
-      Application.put_env(:phoenix_slime, :use_slime_extension, true)
+      Application.put_env(:phoenix_slime, :use_slim_extension, true)
       on_exit fn ->
-        Application.delete_env(:phoenix_slime, :use_slime_extension)
+        Application.delete_env(:phoenix_slime, :use_slim_extension)
       end
       :ok
     end
 
-    test "generates a file with .slime extension " do
-      in_tmp "generates .slime", fn ->
+    test "generates a file with .slim extension " do
+      in_tmp "generates .slim", fn ->
         Mix.Tasks.Phoenix.Gen.Layout.Slime.run []
-        assert File.exists? "web/templates/layout/app.html.slime"
+        assert File.exists? "web/templates/layout/app.html.slim"
       end
     end
   end

--- a/test/phoenix_slime_test.exs
+++ b/test/phoenix_slime_test.exs
@@ -8,7 +8,7 @@ defmodule PhoenixSlimeTest do
     use Phoenix.HTML
   end
 
-  test "render a slim template with layout" do
+  test "render a slime template with layout" do
     html = View.render(MyApp.PageView, "new.html",
       message: "hi",
       layout: {MyApp.PageView, "application.html"}
@@ -16,7 +16,7 @@ defmodule PhoenixSlimeTest do
     assert html == {:safe, [[["" | "<html><body>"], "" | "<h2>New Template</h2>"] | "</body></html>"]}
   end
 
-  test "render a slim template without layout" do
+  test "render a slime template without layout" do
     html = View.render(MyApp.PageView, "new.html", [])
     assert html == {:safe, ["" | "<h2>New Template</h2>"]}
   end


### PR DESCRIPTION
It could be done with following line in config:

```elixir
config :phoenix_slime, :use_slime_extension, true
```

After that all generated files will have `.slime` extension instead of `.slim`. 