### PR TITLE
Add phoenix 1.3 phx prefixed mix tasks

### DIFF
--- a/lib/mix/tasks/phx.gen.html.slime.ex
+++ b/lib/mix/tasks/phx.gen.html.slime.ex
@@ -1,0 +1,191 @@
+defmodule Mix.Tasks.Phx.Gen.Html.Slime do
+  @shortdoc "Generates controller, views, and context for an HTML resource"
+
+  @moduledoc """
+  This file was adapted from the original Phoenix html generator found here:
+  https://github.com/phoenixframework/phoenix/blob/v1.3.0/lib/mix/tasks/phx.gen.html.ex
+
+  Generates controller, views, and context for an HTML resource.
+
+      mix phx.gen.html.slime Accounts User users name:string age:integer
+
+  The first argument is the context module followed by the schema module
+  and its plural name (used as the schema table name).
+
+  The context is an Elixir module that serves as an API boundary for
+  the given resource. A context often holds many related resources.
+  Therefore, if the context already exists, it will be augmented with
+  functions for the given resource. Note a resource may also be split
+  over distinct contexts (such as Accounts.User and Payments.User).
+
+  The schema is responsible for mapping the database fields into an
+  Elixir struct.
+
+  Overall, this generator will add the following files to `lib/`:
+
+    * a context module in lib/app/accounts/accounts.ex for the accounts API
+    * a schema in lib/app/accounts/user.ex, with an `users` table
+    * a view in lib/app_web/views/user_view.slime
+    * a controller in lib/app_web/controllers/user_controller.ex
+    * default CRUD templates in lib/app_web/templates/user
+
+  A migration file for the repository and test files for the context and
+  controller features will also be generated.
+
+  The location of the web files (controllers, views, templates, etc) in an
+  umbrella application will vary based on the `:context_app` config located
+  in your applications `:generators` configuration. When set, the Phoenix
+  generators will generate web files directly in your lib and test folders
+  since the application is assumed to be isolated to web specific functionality.
+  If `:context_app` is not set, the generators will place web related lib
+  and test files in a `web/` directory since the application is assumed
+  to be handling both web and domain specific functionality.
+  Example configuration:
+
+      config :my_app_web, :generators, context_app: :my_app
+
+  Alternatively, the `--context-app` option may be supplied to the generator:
+
+      mix phx.gen.html.slime Sales User users --context-app warehouse
+
+  ## Web namespace
+
+  By default, the controller and view will be namespaced by the schema name.
+  You can customize the web module namespace by passing the `--web` flag with a
+  module name, for example:
+
+      mix phx.gen.html.slime Sales User users --web Sales
+
+  Which would geneate a `lib/app_web/controllers/sales/user_controller.ex` and
+  `lib/app_web/views/sales/user_view.ex`.
+
+  ## Generating without a schema or context file
+
+  In some cases, you may wish to boostrap HTML templates, controllers, and
+  controller tests, but leave internal implementation of the context or schema
+  to yourself. You can use the `--no-context` and `--no-schema` flags for
+  file generation control.
+
+  ## table
+
+  By default, the table name for the migration and schema will be
+  the plural name provided for the resource. To customize this value,
+  a `--table` option may be provided. For example:
+
+      mix phx.gen.html.slime Accounts User users --table cms_users
+
+  ## binary_id
+
+  Generated migration can use `binary_id` for schema's primary key
+  and its references with option `--binary-id`.
+
+  ## Default options
+
+  This generator uses default options provided in the `:generators`
+  configuration of your application. These are the defaults:
+
+      config :your_app, :generators,
+        migration: true,
+        binary_id: false,
+        sample_binary_id: "11111111-1111-1111-1111-111111111111"
+
+  You can override those options per invocation by providing corresponding
+  switches, e.g. `--no-binary-id` to use normal ids despite the default
+  configuration or `--migration` to force generation of the migration.
+
+  Read the documentation for `phx.gen.schema` for more information on
+  attributes.
+  """
+  use Mix.Task
+
+  alias Mix.Phoenix.{Context, Schema}
+  alias Mix.Tasks.Phx.Gen
+
+  import Mix.Tasks.Phx.Gen.Html, only: [print_shell_instructions: 1]
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella? do
+      Mix.raise "mix phx.gen.html.slime can only be run inside an application directory"
+    end
+    {context, schema} = Gen.Context.build(args)
+    binding = [context: context, schema: schema, inputs: inputs(schema)]
+    paths = [".", :phoenix_slime, :phoenix]
+
+    prompt_for_conflicts(context)
+
+    context
+    |> copy_new_files(paths, binding)
+    |> print_shell_instructions()
+  end
+
+  defp prompt_for_conflicts(context) do
+    context
+    |> files_to_be_generated()
+    |> Kernel.++(context_files(context))
+    |> Mix.Phoenix.prompt_for_conflicts()
+  end
+  defp context_files(%Context{generate?: true} = context) do
+    Gen.Context.files_to_be_generated(context)
+  end
+  defp context_files(%Context{generate?: false}) do
+    []
+  end
+
+  @doc false
+  def files_to_be_generated(context) do
+    to_gen = Mix.Tasks.Phx.Gen.Html.files_to_be_generated(context)
+
+    extension = PhoenixSlime.ConfiguredExtension.file_extension
+
+    Enum.map(to_gen, fn
+      {type, name, path} -> {type, name, String.replace_suffix(path, "eex", extension)}
+    end)
+  end
+
+  @doc false
+  def copy_new_files(%Context{} = context, paths, binding) do
+    files = files_to_be_generated(context)
+    Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.html", binding, files)
+    if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+    context
+  end
+
+  defp inputs(%Schema{attrs: attrs}) do
+    Enum.map(attrs, fn
+      {_, {:array, _}} ->
+        {nil, nil, nil}
+      {_, {:references, _}} ->
+        {nil, nil, nil}
+      {key, :integer}    ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :float}      ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, step: "any", class: "form-control"), error(key)}
+      {key, :decimal}    ->
+        {label(key), ~s(= number_input f, #{inspect(key)}, step: "any", class: "form-control"), error(key)}
+      {key, :boolean}    ->
+        {label(key), ~s(= checkbox f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :text}       ->
+        {label(key), ~s(= textarea f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :date}       ->
+        {label(key), ~s(= date_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :time}       ->
+        {label(key), ~s(= time_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :utc_datetime}   ->
+        {label(key), ~s(= datetime_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, :naive_datetime}   ->
+        {label(key), ~s(= datetime_select f, #{inspect(key)}, class: "form-control"), error(key)}
+      {key, _}           ->
+        {label(key), ~s(= text_input f, #{inspect(key)}, class: "form-control"), error(key)}
+    end)
+  end
+
+
+  defp label(key) do
+    ~s(= label f, #{inspect(key)}, class: "control-label")
+  end
+
+  defp error(field) do
+    ~s(= error_tag f, #{inspect(field)})
+  end
+end

--- a/lib/mix/tasks/phx.gen.layout.slime.ex
+++ b/lib/mix/tasks/phx.gen.layout.slime.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Phx.Gen.Layout.Slime do
+  use Mix.Task
+
+  @shortdoc "Generates a default Phoenix layout file in Slime"
+
+  @moduledoc """
+  Generates a Phoenix layout file in Slime.
+
+      mix phx.gen.layout.slime
+
+  """
+  def run(_args) do
+    context_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    binding = [application_module: Mix.Phoenix.base()]
+
+    extension = PhoenixSlime.ConfiguredExtension.file_extension
+    Mix.Phoenix.copy_from(slime_paths(), "priv/templates/phoenix.gen.layout.slime", binding, [
+      {:eex, "app.html.eex", "#{web_prefix}/templates/layout/app.html.#{extension}"}
+    ])
+
+    instructions = """
+
+    A new #{web_prefix}/templates/layout/app.html.#{extension} file was generated.
+    """
+    Mix.shell.info instructions
+  end
+
+  defp slime_paths do
+    [".", :phoenix_slime]
+  end
+end

--- a/priv/templates/phx.gen.html/edit.html.eex
+++ b/priv/templates/phx.gen.html/edit.html.eex
@@ -1,0 +1,5 @@
+h2 Edit <%= schema.human_singular %>
+
+= render "form.html", Map.put(assigns, action: <%= schema.route_helper %>_path(@conn, :update, @<%= schema.singular %>))
+
+= link "Back", to: <%= schema.route_helper %>_path(@conn, :index)

--- a/priv/templates/phx.gen.html/form.html.eex
+++ b/priv/templates/phx.gen.html/form.html.eex
@@ -1,0 +1,10 @@
+= form_for @changeset, @action, fn f ->
+  = if @changeset.action do
+    .alert.alert-danger
+      p Oops, something went wrong! Please check the errors below.
+<%= for {label, input, error} <- inputs, input do %>  .form-group
+    <%= label %>
+    <%= input %>
+    <%= error %>
+<% end %>  .form-group
+    = submit "Submit", class: "btn btn-primary"

--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -1,0 +1,19 @@
+h2 Listing <%= schema.human_plural %>
+
+table.table
+  thead
+    tr
+<%= for {k, _} <- schema.attrs do %>      th <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>
+<% end %>      th
+  tbody
+    = for <%= schema.singular %> <- @<%= schema.plural %> do
+      tr
+<%= for {k, _} <- schema.attrs do %>        td= <%= schema.singular %>.<%= k %>
+<% end %>        td class="text-right"
+          = link "Show", to: <%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>), class: "btn btn-default btn-xs"
+          | &nbsp;
+          = link "Edit", to: <%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>), class: "btn btn-default btn-xs"
+          | &nbsp;
+          = link "Delete", to: <%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs"
+
+= link "New <%= schema.human_singular %>", to: <%= schema.route_helper %>_path(@conn, :new)

--- a/priv/templates/phx.gen.html/new.html.eex
+++ b/priv/templates/phx.gen.html/new.html.eex
@@ -1,0 +1,5 @@
+h2 New <%= schema.human_singular %>
+
+= render "form.html", Map.puts(assigns, action: <%= schema.singular %>_path(@conn, :create))
+
+= link "Back", to: <%= schema.route_helper %>_path(@conn, :index)

--- a/priv/templates/phx.gen.html/show.html.eex
+++ b/priv/templates/phx.gen.html/show.html.eex
@@ -1,0 +1,10 @@
+h2 Show <%= schema.human_singular %>
+
+ul
+<%= for {k, _} <- schema.attrs do %>  li
+    strong <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>:&nbsp;
+    = @<%= schema.singular %>.<%= k %>
+<% end %>
+= link "Edit", to: <%= schema.route_helper %>_path(@conn, :edit, @<%= schema.singular %>)
+| &nbsp;
+= link "Back", to: <%= schema.route_helper %>_path(@conn, :index)

--- a/test/mix/tasks/phx.gen.html.slime_test.exs
+++ b/test/mix/tasks/phx.gen.html.slime_test.exs
@@ -1,0 +1,150 @@
+Code.require_file "../mix_helper.exs", __DIR__
+
+# defmodule PhoenixSlime.DupHTMLController do
+# end
+#
+# defmodule PhoenixSlime.DupHTMLView do
+# end
+
+defmodule Mix.Tasks.Phx.Gen.Html.SlimeTest do
+  use ExUnit.Case
+  import MixHelper
+  alias Mix.Tasks.Phx.Gen
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "generates html resource" do
+    in_tmp "generates html resource", fn ->
+      Gen.Html.Slime.run(
+        ~w(Accounts User users name age:integer height:decimal nicks:array:text
+           famous:boolean born_at:naive_datetime secret:uuid first_login:date
+           alarm:time address_id:references:addresses)
+      )
+
+      assert_file "lib/phoenix_slime/accounts/user.ex"
+      assert_file "lib/phoenix_slime/accounts/accounts.ex"
+      assert_file "test/phoenix_slime/accounts/accounts_test.exs"
+      assert [_] = Path.wildcard("priv/repo/migrations/*_create_users.exs")
+
+      assert_file "lib/phoenix_slime_web/templates/user/edit.html.slime", fn file ->
+        assert file =~ "action: user_path(@conn, :update, @user)"
+      end
+
+      assert_file "lib/phoenix_slime_web/templates/user/form.html.slime", fn file ->
+        assert file =~ ~s(= text_input f, :name, class: "form-control")
+        assert file =~ ~s(= number_input f, :age, class: "form-control")
+        assert file =~ ~s(= number_input f, :height, step: "any", class: "form-control")
+        assert file =~ ~s(= checkbox f, :famous, class: "form-control")
+        assert file =~ ~s(= datetime_select f, :born_at, class: "form-control")
+        assert file =~ ~s(= text_input f, :secret, class: "form-control")
+        assert file =~ ~s(= label f, :name, class: "control-label")
+        assert file =~ ~s(= label f, :age, class: "control-label")
+        assert file =~ ~s(= label f, :height, class: "control-label")
+        assert file =~ ~s(= label f, :famous, class: "control-label")
+        assert file =~ ~s(= label f, :born_at, class: "control-label")
+        assert file =~ ~s(= label f, :secret, class: "control-label")
+
+        refute file =~ ~s(= label f, :address_id)
+        refute file =~ ~s(= number_input f, :address_id)
+        refute file =~ ":nicks"
+      end
+
+      assert_file "lib/phoenix_slime_web/templates/user/index.html.slime", fn file ->
+        assert file =~ "th Name"
+        assert file =~ "= for user <- @users do"
+        assert file =~ "td= user.name"
+      end
+
+      assert_file "lib/phoenix_slime_web/templates/user/new.html.slime", fn file ->
+        assert file =~ "action: user_path(@conn, :create)"
+      end
+
+      assert_file "lib/phoenix_slime_web/templates/user/show.html.slime", fn file ->
+        assert file =~ "strong Name:"
+        assert file =~ "= @user.name"
+      end
+
+      assert_file "test/phoenix_slime_web/controllers/user_controller_test.exs"
+
+      assert_received {:mix_shell, :info, ["\nAdd the resource" <> _ = message]}
+      assert message =~ ~s(resources "/users", UserController)
+    end
+  end
+
+  test "with --web namespace generates namespaced web modules and directories" do
+    in_tmp "generates web resource", fn ->
+      Gen.Html.Slime.run(~w(Blog Post posts title:string --web Blog))
+
+      assert_file "test/phoenix_slime_web/controllers/blog/post_controller_test.exs"
+      assert_file "lib/phoenix_slime_web/controllers/blog/post_controller.ex"
+
+      assert_file "lib/phoenix_slime_web/templates/blog/post/form.html.slime"
+      assert_file "lib/phoenix_slime_web/templates/blog/post/edit.html.slime"
+      assert_file "lib/phoenix_slime_web/templates/blog/post/index.html.slime"
+      assert_file "lib/phoenix_slime_web/templates/blog/post/new.html.slime"
+      assert_file "lib/phoenix_slime_web/templates/blog/post/show.html.slime"
+
+      assert_file "lib/phoenix_slime_web/views/blog/post_view.ex"
+    end
+  end
+
+  test "generates html resource without schema file" do
+    in_tmp "generates html resource without schema", fn ->
+      Gen.Html.Slime.run ~w(Admin User users --no-schema name:string)
+
+      refute_file "lib/phoenix_slime/admin/user.ex"
+
+      assert_file "lib/phoenix_slime_web/templates/user/form.html.slime", fn file ->
+        refute file =~ ~s(--no-schema)
+      end
+    end
+  end
+
+  describe "when :use_slim_extension env is set to true" do
+    setup do
+      Application.put_env(:phoenix_slime, :use_slim_extension, true)
+      on_exit fn ->
+        Application.delete_env(:phoenix_slime, :use_slim_extension)
+      end
+      :ok
+    end
+
+    test "generates files with .slim extension " do
+      in_tmp "generates .slim", fn ->
+        Mix.Tasks.Phx.Gen.Html.Slime.run ~w(Admin User users)
+
+        assert_file "lib/phoenix_slime_web/templates/user/edit.html.slim"
+        assert_file "lib/phoenix_slime_web/templates/user/form.html.slim"
+        assert_file "lib/phoenix_slime_web/templates/user/index.html.slim"
+        assert_file "lib/phoenix_slime_web/templates/user/new.html.slim"
+        assert_file "lib/phoenix_slime_web/templates/user/show.html.slim"
+      end
+    end
+  end
+
+
+  test "plural can't contain a colon" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phx.Gen.Html.Slime.run ["Blog", "Post", "title:string", "content:string"]
+    end
+  end
+
+  test "plural can't have uppercased characters or camelized format" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phx.Gen.Html.Slime.run ["Blog", "User", "Users", "foo:string"]
+    end
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phx.Gen.Html.Slime.run ["Admin", "User", "AdminUsers", "foo:string"]
+    end
+  end
+
+  test "name is already defined" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phx.Gen.Html.Slime.run ["DupHTML", "duphtmls"]
+    end
+  end
+end

--- a/test/mix/tasks/phx.gen.layout.slime_test.exs
+++ b/test/mix/tasks/phx.gen.layout.slime_test.exs
@@ -1,0 +1,41 @@
+Code.require_file "../mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phx.Gen.Layout.SlimeTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "generates a slime layout file" do
+    in_tmp "generates slime layout file", fn ->
+      Mix.Tasks.Phx.Gen.Layout.Slime.run []
+
+      assert_file "lib/phoenix_slime_web/templates/layout/app.html.slime", fn file ->
+        assert file =~ "Hello PhoenixSlime"
+        assert file =~ "p.alert.alert-info"
+        assert file =~ "p.alert.alert-danger"
+      end
+
+    end
+  end
+
+  describe "when :use_slim_extension env is set to true" do
+    setup do
+      Application.put_env(:phoenix_slime, :use_slim_extension, true)
+      on_exit fn ->
+        Application.delete_env(:phoenix_slime, :use_slim_extension)
+      end
+      :ok
+    end
+
+    test "generates a file with .slim extension " do
+      in_tmp "generates .slim", fn ->
+        Mix.Tasks.Phx.Gen.Layout.Slime.run []
+        assert File.exists? "lib/phoenix_slime_web/templates/layout/app.html.slim"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Phoenix 1.3 uses `phx.*` as the prefix for its mix tasks instead of `phoenix.*`. The generated directories are also substantially different. This PR adds `phx.gen.html.slime` and `phx.gen.layout.slime` mix tasks to mimic this behavior with slime templates.