### PR TITLE
Sigil L for safe Slime HTML

### DIFF
--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -1,2 +1,21 @@
 defmodule PhoenixSlime do
+  defmacro sigil_l(expr, opts) do
+    handle_sigil(expr, opts, __CALLER__.line)
+  end
+
+  defmacro sigil_L(expr, opts) do
+    handle_sigil(expr, opts, __CALLER__.line)
+  end
+
+  defp handle_sigil({:<<>>, _, [expr]}, [], line) do
+    expr
+    |> Slime.Renderer.precompile()
+    |> EEx.compile_string(engine: Phoenix.HTML.Engine, line: line + 1)
+  end
+
+  defp handle_sigil(_, _, _) do
+    raise ArgumentError, "Interpolation is not allowed in ~l sigil." <>
+      "Remove the interpolation, use = to insert values, or " <>
+        "use ~L to interpolate."
+  end
 end

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -22,7 +22,7 @@ defmodule PhoenixSlime do
       iex> ~L"\""
       ...> p hello \#{"world"}
       ...> "\""
-      {:safe, ["" | "<p>hello world</p>"]}
+      {:safe, [[["" | "<p>hello "] | "world" ] | "</p>"]}
   """
   defmacro sigil_L(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -20,7 +20,7 @@ defmodule PhoenixSlime do
 
       iex> import PhoenixSlime
       iex> ~L"\""
-      ...> p hello #{"world"}
+      ...> p hello \#{"world"}
       ...> "\""
       {:safe, ["" | "<p>hello world</p>"]}
   """

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -22,7 +22,7 @@ defmodule PhoenixSlime do
       iex> ~L"\""
       ...> p hello #{"world"}
       ...> "\""
-      {:safe, [[["" | "<p>hello "] | "world"] | "</p>"]}
+      {:safe, ["" | "<p>hello world</p>"]}
   """
   defmacro sigil_L(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -1,8 +1,29 @@
 defmodule PhoenixSlime do
+  @doc """
+  Provides the `~l` sigil with HTML safe Slime syntax inside source files.
+
+  Raises on attempts to interpolate with `\#{}`. Use `~L` to interpolate.
+
+      iex> import PhoenixSlime
+      iex> assigns = %{w: "world"}
+      iex> ~l"\""
+      ...> p = "hello " <> @w
+      ...> "\""
+      {:safe, [[["" | "<p>"] | "hello world"] | "</p>"]}
+  """
   defmacro sigil_l(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)
   end
 
+  @doc """
+  Provides the `~L` sigil with HTML safe Slime syntax inside source files.
+
+      iex> import PhoenixSlime
+      iex> ~L"\""
+      ...> p hello #{"world"}
+      ...> "\""
+      {:safe, [[["" | "<p>hello "] | "world"] | "</p>"]}
+  """
   defmacro sigil_L(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)
   end

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -2,7 +2,7 @@ defmodule PhoenixSlime do
   @doc """
   Provides the `~l` sigil with HTML safe Slime syntax inside source files.
 
-  Raises on attempts to interpolate with `\#{}`. Use `~L` to interpolate.
+  Raises on attempts to use `\#{}`. Use `~L` to allow templating with `\#{}`.
 
       iex> import PhoenixSlime
       iex> assigns = %{w: "world"}
@@ -35,8 +35,8 @@ defmodule PhoenixSlime do
   end
 
   defp handle_sigil(_, _, _) do
-    raise ArgumentError, "Interpolation is not allowed in ~l sigil." <>
-      "Remove the interpolation, use = to insert values, or " <>
-        "use ~L to interpolate."
+    raise ArgumentError, ~S(Templating is not allowed with #{} in ~l sigil.) <>
+      ~S( Remove the #{}, use = to insert values, or ) <>
+        ~S(use ~L to template with #{}.)
   end
 end

--- a/test/phoenix_slime_test.exs
+++ b/test/phoenix_slime_test.exs
@@ -1,6 +1,7 @@
 defmodule PhoenixSlimeTest do
   use ExUnit.Case
   alias Phoenix.View
+  doctest PhoenixSlime
 
   defmodule MyApp.PageView do
     use Phoenix.View, root: "test/fixtures/templates"


### PR DESCRIPTION
Closes #61. Sorry about the wait.

This is pretty much the same as in EEx. It just takes the extra step to do the slime precompilation. There is one snag that the precompilation causes. For either `~e` or `~E` sigils in EEx, interpolation isn't allowed. The precompilation doesn't prevent interpolation, so if we use `~L`, we can interpolate. I think it's kind of nice to be able to interpolate, but it might be a little confusing if someone wanted to use the `#{@assign}` syntax in the template.