### PR TITLE
Update the layout to match new default in Phoenix 1.4

### DIFF
--- a/priv/templates/phx.gen.html/edit.html.eex
+++ b/priv/templates/phx.gen.html/edit.html.eex
@@ -1,5 +1,5 @@
-h2 Edit <%= schema.human_singular %>
+h1 Edit <%= schema.human_singular %>
 
 = render "form.html", Map.put(assigns, :action, Routes.<%= schema.route_helper %>_path(@conn, :update, @<%= schema.singular %>))
 
-= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)
+span= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)

--- a/priv/templates/phx.gen.html/form.html.eex
+++ b/priv/templates/phx.gen.html/form.html.eex
@@ -2,9 +2,8 @@
   = if @changeset.action do
     .alert.alert-danger
       p Oops, something went wrong! Please check the errors below.
-<%= for {label, input, error} <- inputs, input do %>  .form-group
-    <%= label %>
-    <%= input %>
-    <%= error %>
-<% end %>  .form-group
-    = submit "Submit", class: "btn btn-primary"
+<%= for {label, input, error} <- inputs, input do %>  <%= label %>
+  <%= input %>
+  <%= error %>
+<% end %>  div
+    = submit "Submit"

--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -1,6 +1,6 @@
-h2 Listing <%= schema.human_plural %>
+h1 Listing <%= schema.human_plural %>
 
-table.table
+table
   thead
     tr
 <%= for {k, _} <- schema.attrs do %>      th <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>
@@ -10,10 +10,8 @@ table.table
       tr
 <%= for {k, _} <- schema.attrs do %>        td= <%= schema.singular %>.<%= k %>
 <% end %>        td class="text-right"
-          = link "Show", to: Routes.<%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>), class: "btn btn-default btn-xs"
-          | &nbsp;
-          = link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>), class: "btn btn-default btn-xs"
-          | &nbsp;
-          = link "Delete", to: Routes.<%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs"
+          = link "Show", to: Routes.<%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>)
+          = link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>)
+          = link "Delete", to: Routes.<%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"]
 
-= link "New <%= schema.human_singular %>", to: Routes.<%= schema.route_helper %>_path(@conn, :new)
+span= link "New <%= schema.human_singular %>", to: Routes.<%= schema.route_helper %>_path(@conn, :new)

--- a/priv/templates/phx.gen.html/new.html.eex
+++ b/priv/templates/phx.gen.html/new.html.eex
@@ -1,5 +1,5 @@
-h2 New <%= schema.human_singular %>
+h1 New <%= schema.human_singular %>
 
 = render "form.html", Map.put(assigns, :action, Routes.<%= schema.singular %>_path(@conn, :create))
 
-= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)
+span= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)

--- a/priv/templates/phx.gen.html/show.html.eex
+++ b/priv/templates/phx.gen.html/show.html.eex
@@ -1,10 +1,9 @@
-h2 Show <%= schema.human_singular %>
+h1 Show <%= schema.human_singular %>
 
 ul
 <%= for {k, _} <- schema.attrs do %>  li
     strong <%= Phoenix.Naming.humanize(Atom.to_string(k)) %>:&nbsp;
     = @<%= schema.singular %>.<%= k %>
 <% end %>
-= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, @<%= schema.singular %>)
-| &nbsp;
-= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)
+span= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, @<%= schema.singular %>)
+span= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index)

--- a/priv/templates/phx.gen.layout.slime/app.html.eex
+++ b/priv/templates/phx.gen.layout.slime/app.html.eex
@@ -4,24 +4,22 @@ html lang="en"
     meta charset="utf-8"
     meta content="IE=edge" http-equiv="X-UA-Compatible"
     meta content="width=device-width, initial-scale=1" name="viewport"
-    meta content="" name="description"
-    meta content="" name="author"
-    title Hello <%= application_module %>!
+    title <%= application_module %> · Phoenix Framework
     link rel="stylesheet" href="#{Routes.static_path(@conn, "/css/app.css")}"
 
   body
-    .container
-      header.header
+    header
+      section.container
         nav role="navigation"
-          ul.nav.nav-pills.pull-right
+          ul
             li
-              a href="http://www.phoenixframework.org/docs" Get Started
-        span.logo
+              a href="https://hexdocs.pm/phoenix/overview.html" Get Started
+        a.phx-logo href="http://phoenixframework.org/"
+          img src="#{ Routes.static_path(@conn, "/images/phoenix.png") }" alt="Phoenix Framework Logo"
 
+    main.container role="main"
       p.alert.alert-info role="alert"= get_flash(@conn, :info)
       p.alert.alert-danger role="alert"= get_flash(@conn, :error)
+      = render @view_module, @view_template, assigns
 
-      main role="main"
-        = render @view_module, @view_template, assigns
-
-    script src="#{Routes.static_path(@conn, "/js/app.js")}"
+    script type="text/javascript" src="#{Routes.static_path(@conn, "/js/app.js")}"

--- a/test/mix/tasks/phx.gen.layout.slime_test.exs
+++ b/test/mix/tasks/phx.gen.layout.slime_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Phx.Gen.Layout.SlimeTest do
       Mix.Tasks.Phx.Gen.Layout.Slime.run([])
 
       assert_file("lib/phoenix_slime_web/templates/layout/app.html.slime", fn file ->
-        assert file =~ "Hello PhoenixSlime"
+        assert file =~ "PhoenixSlime · Phoenix Framework"
         assert file =~ "p.alert.alert-info"
         assert file =~ "p.alert.alert-danger"
       end)


### PR DESCRIPTION
Closes #66 

I saw this and figured it was pretty easy. 

I also noticed that the templates for the `phx.gen.html.slime` task also did not match the 1.4 defaults. Should this PR include those changes as well?

It looks like the current `phx.gen.html.slime` templates are using Bootstrap-like classes (i.e. `btn` and `btn-primary`)?