### PR TITLE
Add PhoenixSlime.LiveViewEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 ```elixir
   config :phoenix, :template_engines,
     slim: PhoenixSlime.Engine,
-    slime: PhoenixSlime.Engine
+    slime: PhoenixSlime.Engine,
+    slimleex: PhoenixSlime.LiveViewEngine # If you want to use LiveView
 ```
 
 An example project can be found at [slime-lang/phoenix_slime_example][phoenix_slime_example].

--- a/lib/phoenix_slime/live_view_engine.ex
+++ b/lib/phoenix_slime/live_view_engine.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixSlime.Engine do
+defmodule PhoenixSlime.LiveViewEngine do
   @behaviour Phoenix.Template.Engine
 
   @doc """
@@ -7,7 +7,7 @@ defmodule PhoenixSlime.Engine do
   def compile(path, _name) do
     path
     |> read!()
-    |> EEx.compile_string(engine: Phoenix.HTML.Engine, file: path, line: 1)
+    |> EEx.compile_string(engine: Phoenix.LiveView.Engine, file: path, line: 1)
   end
 
   defp read!(file_path) do


### PR DESCRIPTION
Regarding #71

This makes it possible to use `phoenix_slime` with Phoenix LiveView.  I will say that while this is working for me, I've noticed that when I'm updating templates in a `for` loop that it's sending down the full HTML of each part rather than the `dynamics`.  I suspect that this is because something like `live_render` still needs to be supported, but this makes for a good first step.