### PR TITLE
Update README to a version that supports LiveView

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Usage
 
-  1. Add `{:phoenix_slime, "~> 0.12.0"}` to your deps in `mix.exs`.
+  1. Add `{:phoenix_slime, "~> 0.13.1"}` to your deps in `mix.exs`.
   2. Add the following to your Phoenix `config/config.exs`:
 
 ```elixir


### PR DESCRIPTION
I installed phoenix_slime according to the docs, but found that when using the `.slimeleex` extension the compile would blow up with:

```
** (UndefinedFunctionError) function PhoenixSlime.LiveViewEngine.compile/2 is undefined (module PhoenixSlime.LiveViewEngine is not available)
```

Previously the README referenced `0.12.0`.  Updating to the latest release (`0.13.1`, where LiveView support was added in `0.13.0`) fixes the problem, so in this PR we update the README to reflect this.
