### PR TITLE
Add source path to TemplateSyntaxError

### DIFF
--- a/lib/phoenix_slime/engine.ex
+++ b/lib/phoenix_slime/engine.ex
@@ -18,5 +18,7 @@ defmodule PhoenixSlime.Engine do
     file_path
     |> File.read!()
     |> Slime.Renderer.precompile()
+  rescue
+    e in Slime.TemplateSyntaxError -> reraise %{e | source: file_path}, __STACKTRACE__
   end
 end


### PR DESCRIPTION
Improves the error's visibility by adding a path to a source.

before:
```
== Compilation error in file lib/app_web/views/page_view.ex ==
** (Slime.TemplateSyntaxError) Unexpected indent
INPUT, Line 2, Column 0
  .panel-heading
```

after:
```
== Compilation error in file lib/app_web/views/page_view.ex ==
** (Slime.TemplateSyntaxError) Unexpected indent
lib/app_web/templates/page/_comments.html.slim, Line 2, Column 0
  .panel-heading
```